### PR TITLE
Add missing flexbox props.

### DIFF
--- a/src/prefixProps.js
+++ b/src/prefixProps.js
@@ -6,6 +6,12 @@ module.exports = {
   'flex': 1,
   'flexFlow': 1,
   'flexGrow': 1,
+  'flexShrink': 1,
+  'flexBasis': 1,
+  'flexDirection': 1,
+  'flexWrap': 1,
+  'alignContent': 1,
+  'alignSelf': 1,
 
   'userSelect': 1,
   'transform': 1,


### PR DESCRIPTION
Adding the flex box properties that I did in prefixProps.js fixes most issues I was having with reapp flexbox rendering in Safari, but I'm still not getting flex: 1 normalized to -webkit-flex: 1. Not sure yet if it's an issue in react-style-normalizer or reapp-ui. Looks like 'flex' is already in the props list, but Safari is still getting flex: 1 which is not allowing elements to stretch when they should be. @radubrehar, @natew, any thoughts?